### PR TITLE
Test suite for akka integration via reactive streams

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,26 @@
       <scope>test</scope>
       <version>4.11</version>
     </dependency>
+
+    <!-- AKKA AND SCALA DEPENDECNIES -->
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>2.11.4</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.typesafe.akka</groupId>
+      <artifactId>akka-actor_2.11</artifactId>
+      <version>2.3.9</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.typesafe.akka</groupId>
+      <artifactId>akka-stream-experimental_2.11</artifactId>
+      <version>1.0-M5</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -134,6 +154,19 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.scala-tools</groupId>
+        <artifactId>maven-scala-plugin</artifactId>
+        <version>2.15.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -115,19 +115,19 @@
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
       <version>2.11.4</version>
-      <scope>provided</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
       <artifactId>akka-actor_2.11</artifactId>
       <version>2.3.9</version>
-      <scope>provided</scope>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>
       <artifactId>akka-stream-experimental_2.11</artifactId>
       <version>1.0-M5</version>
-      <scope>provided</scope>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/test/scala/io/vertx/ext/reactivestreams/akka/test/AkkaRandomValuesStream.scala
+++ b/src/test/scala/io/vertx/ext/reactivestreams/akka/test/AkkaRandomValuesStream.scala
@@ -1,0 +1,38 @@
+package io.vertx.ext.reactivestreams.akka.test
+
+import akka.actor.ActorSystem
+import akka.stream.ActorFlowMaterializer
+import akka.stream.scaladsl.{Broadcast, FlowGraph, Sink, Source}
+import io.vertx.core.buffer.Buffer
+import org.reactivestreams.Subscriber
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success}
+
+class AkkaRandomValuesStream(subscriber: Subscriber[Buffer]) {
+  implicit val system = ActorSystem("Sys")
+  implicit val materializer = ActorFlowMaterializer()
+  val bufferSource: Source[Buffer, Unit] =
+    Source(() => Iterator.continually(Buffer.buffer("random value")))
+  val mySink = Sink.apply(subscriber);
+  val consoleSink = Sink.foreach[Buffer] { value =>
+//      println("console "+value.getString(0, value.length()))
+    ()
+  }
+
+  val materialized = FlowGraph.closed(consoleSink, mySink)((console, _) => console) { implicit builder =>
+    (console, mine) =>
+      import FlowGraph.Implicits._
+      val broadcast = builder.add(Broadcast[Buffer](2))
+      bufferSource ~> broadcast ~> console
+      broadcast ~> mine
+  }.run()
+
+  materialized.onComplete {
+    case Success(_) =>
+      system.shutdown()
+    case Failure(e) =>
+      println(s"Failure: ${e.getMessage}")
+      system.shutdown()
+  }
+}

--- a/src/test/scala/io/vertx/ext/reactivestreams/akka/test/AkkaRandomValuesStreamTest.scala
+++ b/src/test/scala/io/vertx/ext/reactivestreams/akka/test/AkkaRandomValuesStreamTest.scala
@@ -1,0 +1,45 @@
+package io.vertx.ext.reactivestreams.akka.test
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+import io.vertx.core.Handler
+import io.vertx.core.buffer.Buffer
+import io.vertx.ext.reactivestreams.ReactiveReadStream
+import junit.framework.Assert._
+import org.junit.Test
+import org.reactivestreams.{Subscription, Subscriber}
+
+/**
+ * Created by Jochen Mader
+ */
+class AkkaRandomValuesStreamTest {
+
+  @Test
+  def testWithReactiveReadStream {
+    val rws: ReactiveReadStream[Buffer] = ReactiveReadStream.readStream[Buffer]
+    val cl = new CountDownLatch(1)
+    rws.handler(new Handler[Buffer] {
+      override def handle(e: Buffer): Unit = cl.countDown()
+    })
+    val akkaRandomValuesStream = new AkkaRandomValuesStream(rws)
+    rws.resume
+    assertTrue("Timed out while waiting for events", cl.await(200, TimeUnit.MILLISECONDS))
+  }
+
+  @Test
+  def testWithCustomSubscriber {
+    val cl = new CountDownLatch(1)
+
+    val akkaRandomValuesStream = new AkkaRandomValuesStream(new Subscriber[Buffer] {override def onError(throwable: Throwable): Unit = ???
+
+      override def onSubscribe(subscription: Subscription): Unit = subscription.request(1)
+
+      override def onComplete(): Unit = ???
+
+      override def onNext(t: Buffer): Unit = cl.countDown()
+
+    });
+
+    assertTrue("Timed out while waiting for events", cl.await(200, TimeUnit.MILLISECONDS))
+  }
+}


### PR DESCRIPTION
I included 2 tests for Akka-integration.
testWithReactiveReadStream uses the ReactiveReadStream from Vert.x This tests fails from time to time. My guess is that there is some deadlock with your current implementation. Hopefully I will have some time to look at it by next week.

testWithCustomSubscriber uses a custom Subscriber implementation. This test works reliably and I created it to see if I was doing something wrong in testWithReactiveReadStream.

All Scala and Akka-related deps are in scope "test" and shouldn't cause trouble with deployed versions.