### PR TITLE
Prevent ConcurrentModificationException in ReactiveWriteStreamImpl

### DIFF
--- a/src/main/java/io/vertx/ext/reactivestreams/impl/ReactiveWriteStreamImpl.java
+++ b/src/main/java/io/vertx/ext/reactivestreams/impl/ReactiveWriteStreamImpl.java
@@ -23,7 +23,11 @@ import io.vertx.ext.reactivestreams.ReactiveWriteStream;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -31,7 +35,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class ReactiveWriteStreamImpl<T> implements ReactiveWriteStream<T> {
 
-  private Set<SubscriptionImpl> subscriptions = new HashSet<>();
+  private final Set<SubscriptionImpl> subscriptions = ConcurrentHashMap.newKeySet();
   private final Queue<Item<T>> pending = new ArrayDeque<>();
   private Handler<Void> drainHandler;
   private int writeQueueMaxSize = DEFAULT_WRITE_QUEUE_MAX_SIZE;


### PR DESCRIPTION
This can happen because the subscriptions set is not fully guarded by the write stream instance.

The problem was detected by an intermittent test failure:

```
2025-01-02T05:02:34.8012054Z [ERROR] Tests run: 8, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.071 s <<< FAILURE! -- in io.vertx.ext.reactivestreams.test.ReactiveWriteStreamTest
2025-01-02T05:02:34.8014457Z [ERROR] io.vertx.ext.reactivestreams.test.ReactiveWriteStreamTest.testCancelSubscriptionOnError2 -- Time elapsed: 0.017 s <<< ERROR!
2025-01-02T05:02:34.8015664Z java.util.ConcurrentModificationException
2025-01-02T05:02:34.8018887Z 	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1605)
2025-01-02T05:02:34.8020228Z 	at java.base/java.util.HashMap$KeyIterator.next(HashMap.java:1628)
2025-01-02T05:02:34.8021576Z 	at io.vertx.reactivestreams@5.0.0-SNAPSHOT/io.vertx.ext.reactivestreams.impl.ReactiveWriteStreamImpl.sendToSubscribers(ReactiveWriteStreamImpl.java:180)
2025-01-02T05:02:34.8023038Z 	at io.vertx.reactivestreams@5.0.0-SNAPSHOT/io.vertx.ext.reactivestreams.impl.ReactiveWriteStreamImpl.checkSend(ReactiveWriteStreamImpl.java:146)
2025-01-02T05:02:34.8024281Z 	at io.vertx.reactivestreams@5.0.0-SNAPSHOT/io.vertx.ext.reactivestreams.impl.ReactiveWriteStreamImpl.write(ReactiveWriteStreamImpl.java:75)
2025-01-02T05:02:34.8025374Z 	at io.vertx.reactivestreams.tests/io.vertx.ext.reactivestreams.test.ReactiveWriteStreamTest.testCancelSubscriptionOnError2(ReactiveWriteStreamTest.java:329)
```